### PR TITLE
Refactor: Migrate extension settings from YAML to VS Code Settings API

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,58 @@
           }
         ]
       }
-    ]
+    ],
+    "configuration": {
+      "type": "object",
+      "title": "BPMN.flex Configuration",
+      "properties": {
+        "bpmn-flex.commonProperties": {
+          "type": "array",
+          "description": "Define common properties applicable to all BPMN elements.",
+          "items": {
+            "type": "object",
+            "title": "Common Property",
+            "properties": {
+              "label": {
+                "type": "string",
+                "description": "The display label for the property."
+              },
+              "xpath": {
+                "type": "string",
+                "description": "The XPath expression to select the property's value from the BPMN XML."
+              }
+            },
+            "required": ["label", "xpath"]
+          },
+          "default": []
+        },
+        "bpmn-flex.elementSpecificProperties": {
+          "type": "object",
+          "description": "Define properties specific to certain BPMN element types. Use the BPMN element type (e.g., 'bpmn:Task', 'bpmn:UserTask') as the key.",
+          "additionalProperties": {
+            "type": "array",
+            "description": "Properties for the specified element type.",
+            "items": {
+              "type": "object",
+              "title": "Element Specific Property",
+              "properties": {
+                "label": {
+                  "type": "string",
+                  "description": "The display label for the property."
+                },
+                "xpath": {
+                  "type": "string",
+                  "description": "The XPath expression to select the property's value from the BPMN XML for this element type."
+                }
+              },
+              "required": ["label", "xpath"]
+            },
+            "default": []
+          },
+          "default": {}
+        }
+      }
+    }
   },
   "scripts": {
     "all": "run-s lint test",
@@ -111,7 +162,6 @@
     "@rollup/plugin-url": "^8.0.2",
     "@types/chai": "^4.3.20",
     "@types/glob": "^8.1.0",
-    "@types/js-yaml": "^4.0.9",
     "@types/mocha": "^10.0.9",
     "@types/node": "^20.17.6",
     "@types/shelljs": "^0.8.15",
@@ -140,7 +190,6 @@
     "bpmn-js": "^18.6.1",
     "bpmn-js-color-picker": "^0.7.1",
     "bpmn-js-i18n": "^2.3.0",
-    "js-yaml": "^4.1.0",
     "xmldom": "^0.6.0",
     "xpath": "^0.0.34"
   }


### PR DESCRIPTION
This commit changes how the BPMN.flex extension loads its custom properties configuration. Instead of using a `.vscode/bpmn-custom-properties.yaml` file, the extension now utilizes the standard VS Code settings API.

Key changes:
- Added `contributes.configuration` to `package.json` to define settings for `bpmn-flex.commonProperties` and `bpmn-flex.elementSpecificProperties`. This allows you to configure properties via the VS Code Settings UI.
- Modified `src/extension.ts` to access these settings using `vscode.workspace.getConfiguration('bpmn-flex')`.
- Removed the YAML file handling logic and the `js-yaml` dependency.

This change provides a more integrated experience for you, allowing you to manage extension settings alongside other VS Code preferences.